### PR TITLE
Allow unicode characters in YAML ruleset-file

### DIFF
--- a/gmail_yaml_filters/main.py
+++ b/gmail_yaml_filters/main.py
@@ -595,7 +595,7 @@ def main():
     ruleset = RuleSet.from_object(rule for rule in data if not rule.get('ignore'))
 
     if args.action == 'xml':
-        print(ruleset_to_xml(ruleset))
+        print(ruleset_to_xml(ruleset).encode('utf-8'))
     elif args.action == 'upload':
         upload_ruleset(ruleset, dry_run=args.dry_run)
     elif args.action == 'prune':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 lxml
 pyyaml
+oauth2client


### PR DESCRIPTION
This allows the ruleset YAML file to be formatted in UTF-8 and include Unicode characters.