### PR TITLE
Allow native application OAuth 2 client flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ If you are the trusting type, you can authorize the script to
 upload new filters and remove obsolete filters via Gmail's API.
 Before using any of these commands, you will need to create
 [`client_secret.json`](https://developers.google.com/identity/protocols/oauth2/web-server#creatingcred)
-and store it in the same directory as your YAML file.
+and store it in the same directory as your YAML file. Use the
+`--noauth_local_webserver` option when using the secret to
+authenticate for the first time.
 
 ```bash
 # Upload all filters (and create new labels) from the configuration file


### PR DESCRIPTION
The command line does not provide a way to use the standard
`--noauth_local_webserver` option provided by the `oauth2client` library
for the `tools.run_flow()` method. Integrates the provided
`ArgumentParser` instance in the recommended way:

https://oauth2client.readthedocs.io/en/latest/source/oauth2client.tools.html#oauth2client.tools.run_flow

Also allows offline use when just generating XML.