### PR TITLE
Add test-requirements.txt for convenience

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,3 @@
+pytest
+mock
+flake8


### PR DESCRIPTION
Running tox can take a long time. For basic sanity checks using py.test
and flake8 without incurring the setup overhead, it's convenient to have
the test dependencies in a common place for quick installation.