### PR TITLE
Ignore *.pyc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .cache
 .tox
 __pycache__
+*.pyc
 build/
 dist/
 venv_*/


### PR DESCRIPTION
The tox configuration still runs Python 2.7 tests, so `.pyc` files
appear in the working copy. Added entry to `.gitignore`.