### PR TITLE
Fixes for #14 and #15

### DIFF
--- a/gmail_yaml_filters/main.py
+++ b/gmail_yaml_filters/main.py
@@ -57,6 +57,8 @@ def create_parser():
     # Actions
     parser.add_argument('--upload', dest='action', action='store_const', const='upload',
                         help='create filters and labels in Gmail')
+    parser.add_argument('--delete', dest='action', action='store_const', const='delete',
+                        help='Deletes all filters in Gmail')
     parser.add_argument('--prune', dest='action', action='store_const', const='prune',
                         help='delete any Gmail filters that are not defined in the configuration file')
     parser.add_argument('--sync', dest='action', action='store_const', const='upload_prune',
@@ -99,7 +101,10 @@ def main():
     credentials = get_gmail_credentials(client_secret_path=args.client_secret)
     gmail = get_gmail_service(credentials)
 
-    if args.action == 'upload':
+    if args.action == 'delete':
+        emptyruleset={}
+        prune_filters_not_in_ruleset(emptyruleset, service=gmail, dry_run=args.dry_run)
+    elif args.action == 'upload':
         upload_ruleset(ruleset, service=gmail, dry_run=args.dry_run)
     elif args.action == 'prune':
         prune_filters_not_in_ruleset(ruleset, service=gmail, dry_run=args.dry_run)

--- a/gmail_yaml_filters/ruleset.py
+++ b/gmail_yaml_filters/ruleset.py
@@ -599,7 +599,7 @@ def ruleset_to_etree(ruleset):
         'apps': 'http://schemas.google.com/apps/2006',
     })
     etree.SubElement(xml, 'title').text = 'Mail Filters'
-    for rule in sorted(ruleset):
+    for rule in ruleset:
         if not rule.publishable:
             continue
         entry = etree.SubElement(xml, 'entry')

--- a/gmail_yaml_filters/ruleset.py
+++ b/gmail_yaml_filters/ruleset.py
@@ -178,6 +178,7 @@ class RuleCondition(_RuleConstruction):
         'does_not_have': 'doesNotHaveTheWord',
         'missing': 'doesNotHaveTheWord',
         'no_match': 'doesNotHaveTheWord',
+	'smartlabel': 'smartLabelToApply',
     }
 
     formatter_map = {

--- a/gmail_yaml_filters/upload.py
+++ b/gmail_yaml_filters/upload.py
@@ -275,7 +275,9 @@ def get_gmail_credentials(
         flow = oauth2client.client.flow_from_clientsecrets(client_secret_path, scopes)
         flow.user_agent = application_name
         flags_parser = argparse.ArgumentParser(parents=[oauth2client.tools.argparser])
-        credentials = oauth2client.tools.run_flow(flow, store, flags=flags_parser.parse_args([]))
+        flags=flags_parser.parse_args([])
+        flags.noauth_local_webserver = True
+        credentials = oauth2client.tools.run_flow(flow, store, flags)
         print('Storing credentials to', credential_path, file=sys.stderr)
 
     return credentials

--- a/gmail_yaml_filters/upload.py
+++ b/gmail_yaml_filters/upload.py
@@ -8,6 +8,7 @@ from operator import itemgetter
 import argparse
 import os
 import sys
+import time
 
 # google-api-python-client dependencies
 import apiclient.discovery
@@ -198,6 +199,7 @@ def upload_ruleset(ruleset, service=None, dry_run=False):
             request = service.users().settings().filters().create(userId='me', body=filter_data)
             if not dry_run:
                 request.execute()
+                time.sleep(1.5)
 
 
 def find_filters_not_in_ruleset(ruleset, service, dry_run):


### PR DESCRIPTION
So removing the sorting of the ruleset (a39fd64) allows for the rules to be output in yaml file order.

Adding a delete all rules (f1652b7) and then re-uploading the rules with a delay (115c5aa) has all the rules in Gmail in the same order as the yaml file.

I also changed the OATH2 to token response (eeefdab) because the webserver wasn't working and token always works.

I also added a smartlabel alternative (6ab9bed) for the "Categories"