### PR TITLE
Allow overriding credentials file name with CLI

### DIFF
--- a/gmail_yaml_filters/main.py
+++ b/gmail_yaml_filters/main.py
@@ -54,6 +54,8 @@ def create_parser():
                         help='do not make any API calls to Gmail')
     parser.add_argument('--client-secret', metavar='CLIENT_SECRET_FILE', nargs='?',
                         help='path to client_secret.json; default is wherever the configuration file is located')
+    parser.add_argument('--credentials-profile', default='gmail_yaml_filters',
+                        help='name to use for credentials file, to keep credentials separate')
     # Actions
     parser.add_argument('--upload', dest='action', action='store_const', const='upload',
                         help='create filters and labels in Gmail')
@@ -96,7 +98,8 @@ def main():
 
     # every command below this point involves the Gmail API
 
-    credentials = get_gmail_credentials(client_secret_path=args.client_secret)
+    credentials = get_gmail_credentials(client_secret_path=args.client_secret,
+                                        application_name=args.credentials_profile)
     gmail = get_gmail_service(credentials)
 
     if args.action == 'upload':


### PR DESCRIPTION
Exposes the `application_name` argument to `get_gmail_credentials()` as a `--credentials-profile` argument, allowing multiple accounts' credentials to be stored in parallel in the `~/.credentials` directory.