### PR TITLE
Fix #33 (implement smart labels as `categorize` action and remove doc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.6
+
+* Fix #33 (implement smart labels as `categorize` action and remove documentation about CATEGORY_* labels that do not place emails into the tab categories.
+
 # 0.9.5
 
 * Fix #28 (pruning a filter with no actions would cause a crash)

--- a/README.md
+++ b/README.md
@@ -127,12 +127,13 @@ Supported actions:
 * `archive`
 * `forward`
 * `important` (also `mark_as_important`)
-* `label`, including support for Gmail's [category tabs](https://developers.google.com/gmail/api/guides/labels):
-  * `CATEGORY_PERSONAL`
-  * `CATEGORY_SOCIAL`
-  * `CATEGORY_PROMOTIONS`
-  * `CATEGORY_UPDATES`
-  * `CATEGORY_FORUMS`
+* `label`
+* `categorize`, smart labels for Gmail's category tabs. Supported values:
+  * `^smartlabel_personal` (Primary tab)
+  * `^smartlabel_social` (Social tab)
+  * `^smartlabel_promo` (Promotions tab)
+  * `^smartlabel_notification` (Updates tab)
+  * `^smartlabel_group` (Forums tab)
 * `not_important` (also `never_mark_as_important`)
 * `not_spam`
 * `read` (also `mark_as_read`)

--- a/gmail_yaml_filters/ruleset.py
+++ b/gmail_yaml_filters/ruleset.py
@@ -241,6 +241,7 @@ class RuleAction(_RuleConstruction):
     """
     identifier_map = {
         'label': 'label',
+        'categorize': 'smartLabelToApply',
         'important': 'shouldAlwaysMarkAsImportant',
         'mark_as_important': 'shouldAlwaysMarkAsImportant',
         'not_important': 'shouldNeverMarkAsImportant',

--- a/gmail_yaml_filters/tests/test_ruleset.py
+++ b/gmail_yaml_filters/tests/test_ruleset.py
@@ -134,6 +134,7 @@ def test_foreach():
             'from': '{item}@aapl.com',
             'star': True,
             'important': True,
+            'categorize': '^smartlabel_personal',
             'more': [
                 {'label': 'everyone', 'to': 'everyone@aapl.com'},
             ]
@@ -164,6 +165,7 @@ def test_foreach_dict():
             'from': '{email}@aapl.com',
             'to': '{team}@aapl.com',
             'star': True,
+            'categorize': '^smartlabel_notification',
         }
     })
     assert sorted(rule.conditions for rule in ruleset) == [


### PR DESCRIPTION
…umentation about CATEGORY_* labels that do not place emails into the tab categories.